### PR TITLE
Upgrade to scalding 0.12 and other transitive dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies += "cascading.kryo" % "cascading.kryo" % "0.4.6"
 
 libraryDependencies += "com.google.code.gson" % "gson" % "2.2.2"
 
-libraryDependencies += "com.twitter" % "maple" % "0.2.4"
+libraryDependencies += "com.twitter" % "maple" % "0.12.0"
 
 libraryDependencies += "com.twitter" % "algebird-core" % "0.7.1" cross CrossVersion.binaryMapped {
   case "2.9.3" => "2.9.3"

--- a/build.sbt
+++ b/build.sbt
@@ -30,11 +30,11 @@ resolvers ++= {
   )
 }
 
-libraryDependencies += "cascading" % "cascading-core" % "2.0.0"
+libraryDependencies += "cascading" % "cascading-core" % "2.6.1"
 
-libraryDependencies += "cascading" % "cascading-local" % "2.0.0" exclude("com.google.guava", "guava")
+libraryDependencies += "cascading" % "cascading-local" % "2.6.1" exclude("com.google.guava", "guava")
 
-libraryDependencies += "cascading" % "cascading-hadoop" % "2.0.0"
+libraryDependencies += "cascading" % "cascading-hadoop" % "2.6.1"
 
 libraryDependencies += "cascading.kryo" % "cascading.kryo" % "0.4.6"
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,8 +47,8 @@ libraryDependencies += "com.twitter" % "algebird-core" % "0.1.12" cross CrossVer
   case _ => "2.10"
 }
 
-libraryDependencies += "com.twitter" % "scalding-core" % "0.8.5" cross CrossVersion.binaryMapped {
-  case "2.9.3" => "2.9.2"
+libraryDependencies += "com.twitter" % "scalding-core" % "0.12.0" cross CrossVersion.binaryMapped {
+  case "2.9.3" => "2.9.3"
   case _ => "2.10"
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,8 +42,8 @@ libraryDependencies += "com.google.code.gson" % "gson" % "2.2.2"
 
 libraryDependencies += "com.twitter" % "maple" % "0.2.4"
 
-libraryDependencies += "com.twitter" % "algebird-core" % "0.1.12" cross CrossVersion.binaryMapped {
-  case "2.9.3" => "2.9.2"
+libraryDependencies += "com.twitter" % "algebird-core" % "0.7.1" cross CrossVersion.binaryMapped {
+  case "2.9.3" => "2.9.3"
   case _ => "2.10"
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -68,11 +68,11 @@ libraryDependencies += "com.google.guava" % "guava" % "13.0.1"
 
 libraryDependencies += "org.apache.commons" % "commons-math3" % "3.2"
 
-libraryDependencies += "org.apache.hadoop" % "hadoop-common" % "2.0.0-cdh4.1.1" exclude("commons-daemon", "commons-daemon")
+libraryDependencies += "org.apache.hadoop" % "hadoop-common" % "2.5.0-cdh5.2.1" exclude("commons-daemon", "commons-daemon")
 
-libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % "2.0.0-cdh4.1.1" exclude("commons-daemon", "commons-daemon")
+libraryDependencies += "org.apache.hadoop" % "hadoop-hdfs" % "2.5.0-cdh5.2.1" exclude("commons-daemon", "commons-daemon")
 
-libraryDependencies += "org.apache.hadoop" % "hadoop-tools" % "2.0.0-mr1-cdh4.1.1" exclude("commons-daemon", "commons-daemon")
+libraryDependencies += "org.apache.hadoop" % "hadoop-tools" % "2.5.0-mr1-cdh5.2.1" exclude("commons-daemon", "commons-daemon")
 
 libraryDependencies += "net.sf.trove4j" % "trove4j" % "3.0.3"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.4

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.12.1

--- a/src/main/scala/com/etsy/conjecture/scalding/ALSJob.scala
+++ b/src/main/scala/com/etsy/conjecture/scalding/ALSJob.scala
@@ -27,7 +27,7 @@ import org.apache.commons.math3.linear._
 
 abstract class ALSJob[R, C](args : Args) extends Job(args) {
 
-  override def config(implicit mode : Mode): Map[AnyRef, AnyRef] =
+  override def config: Map[AnyRef, AnyRef] =
     super.config + ("mapred.child.java.opts" -> "-Xmx3G")
 
   // Dimension of latent factors.

--- a/src/main/scala/com/etsy/conjecture/scalding/train/LargeModelTrainer.scala
+++ b/src/main/scala/com/etsy/conjecture/scalding/train/LargeModelTrainer.scala
@@ -64,7 +64,7 @@ class LargeModelTrainer[L <: Label, M <: UpdateableModel[L, M]](strategy: ModelT
                     }
                 }
             }
-            .groupBy('param) { _.sum('value).forceToReducers }
+            .groupBy('param) { _.sum[Double]('value).forceToReducers }
             // Duplicate the summed parameters rather than duplicating the reconstructed model, for speed reasons.
             .flatMapTo(('param, 'value) -> ('bin, 'param, 'value)) {
                 b: (String, Double) =>

--- a/src/main/scala/com/etsy/conjecture/text/FeatureHelper.scala
+++ b/src/main/scala/com/etsy/conjecture/text/FeatureHelper.scala
@@ -25,7 +25,7 @@ object FeatureHelper {
                     }
                     vector.keySet.asScala.map { k => k -> 1 }
             }
-            .groupBy('term) { _.sum('__count) }
+            .groupBy('term) { _.sum[Int]('__count) }
             .filter('__count) { c: Long => c > n }
             .mapTo('term -> 'set) { t: String => Set(t) }
             .groupAll { _.plus[Set[String]]('set) }

--- a/src/main/scala/com/etsy/conjecture/text/FeatureHelper.scala
+++ b/src/main/scala/com/etsy/conjecture/text/FeatureHelper.scala
@@ -25,7 +25,7 @@ object FeatureHelper {
                     }
                     vector.keySet.asScala.map { k => k -> 1 }
             }
-            .groupBy('term) { _.sum[Int]('__count) }
+            .groupBy('term) { _.sum[Long]('__count) }
             .filter('__count) { c: Long => c > n }
             .mapTo('term -> 'set) { t: String => Set(t) }
             .groupAll { _.plus[Set[String]]('set) }

--- a/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocClassifier.scala
+++ b/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocClassifier.scala
@@ -43,6 +43,6 @@ class AdHocClassifier(args : Args) extends Job(args) {
       .write(SequenceFile(out_dir + "/pred"))
   }
 
-  override def config(implicit mode : Mode) = super.config ++
+  override def config = super.config ++
     Map("mapred.child.java.opts" -> "-Xmx%dG".format(xmx))
 }

--- a/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocClusterer.scala
+++ b/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocClusterer.scala
@@ -166,7 +166,7 @@ class AdHocClustererTest(args: Args) extends Job(args) {
 
       /** Sum all closest distances into a normalizer **/
       val normalizer = closest_distances
-        .groupAll{ _.sum('closest_distance -> 'denominator) }
+        .groupAll{ _.sum[Double]('closest_distance -> 'denominator) }
     
       /** 
        * Normalize each points' distance to it's nearest cluster center to a probability. 
@@ -317,6 +317,6 @@ class AdHocClustererTest(args: Args) extends Job(args) {
       }   
     }
 
-    override def config(implicit mode : Mode) = super.config ++
+    override def config = super.config ++
       Map("mapred.child.java.opts" -> "-Xmx%dG".format(xmx))
 }

--- a/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocMulticlassClassifier.scala
+++ b/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocMulticlassClassifier.scala
@@ -44,6 +44,6 @@ class AdHocMulticlassClassifier(args : Args) extends Job(args) {
       .write(SequenceFile(out_dir + "/pred"))
   }
 
-  override def config(implicit mode : Mode) = super.config ++
+  override def config = super.config ++
     Map("mapred.child.java.opts" -> "-Xmx%dG".format(xmx))
 }

--- a/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocPredictor.scala
+++ b/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocPredictor.scala
@@ -39,7 +39,7 @@ class AdHocPredictor(args : Args) extends Job(args) {
     .groupAll { _.sortBy('pred).reverse }
     .write(SequenceFile(out_dir + "/pred"))
 
-  override def config(implicit mode : Mode) = super.config ++
+  override def config = super.config ++
     Map("mapred.child.java.opts" -> "-Xmx%dG".format(xmx))
 
 }

--- a/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocPredictor.scala
+++ b/src/main/scala/com/etsy/scalding/jobs/conjecture/AdHocPredictor.scala
@@ -41,6 +41,7 @@ class AdHocPredictor(args : Args) extends Job(args) {
     .write(SequenceFile(out_dir + "/pred"))
 
   override def config = super.config ++
+    Map("mapred.child.java.opts" -> "-Xmx%dG".format(xmx),
         "mapreduce.map.memory.mb" -> containerMemory.toString,
         "mapreduce.reduce.memory.mb" -> containerMemory.toString
     )


### PR DESCRIPTION
This PR upgrades scalding to version 0.12.0. In order to avoid subtle bugs, this also bumps maple and algebird (scalding dependencies that conjecture also uses) to the versions that scalding 0.12.0 depends on.

In addition, I've also bumped cascading and cdh dependendcies. I could pull this out into a separate PR if you like, but I figured one PR would be easier to review.