### PR TITLE
AdHocPredictor: --skip_final_sort option to avoid single-reducer bottleneck

### DIFF
--- a/src/main/java/com/etsy/conjecture/model/AdagradOptimizer.java
+++ b/src/main/java/com/etsy/conjecture/model/AdagradOptimizer.java
@@ -1,18 +1,15 @@
 package com.etsy.conjecture.model;
 
-import com.etsy.conjecture.data.LazyVector;
-import com.etsy.conjecture.data.StringKeyedVector;
-import static com.google.common.base.Preconditions.checkArgument;
-import com.etsy.conjecture.Utilities;
-import com.etsy.conjecture.data.LabeledInstance;
-import java.util.Map;
-import java.util.Iterator;
+import com.etsy.conjecture.*;
+import com.etsy.conjecture.data.*;
+
+import java.util.*;
 
 /**
  *  AdaGrad provides adaptive per-feature learning rates at each time step t.
  *  Described here: http://www.ark.cs.cmu.edu/cdyer/adagrad.pdf
  */
-public class AdagradOptimizer extends SGDOptimizer {
+public class AdagradOptimizer<L extends Label> extends SGDOptimizer<L> {
 
     private StringKeyedVector unnormalizedGradients = new StringKeyedVector();
     private StringKeyedVector summedGradients = new StringKeyedVector();

--- a/src/main/java/com/etsy/conjecture/model/ControlOptimizer.java
+++ b/src/main/java/com/etsy/conjecture/model/ControlOptimizer.java
@@ -1,17 +1,13 @@
 package com.etsy.conjecture.model;
 
-import com.etsy.conjecture.data.LazyVector;
-import com.etsy.conjecture.data.StringKeyedVector;
-import static com.google.common.base.Preconditions.checkArgument;
-import com.etsy.conjecture.Utilities;
-import com.etsy.conjecture.data.LabeledInstance;
-import java.util.Map;
-import java.util.Iterator;
+import com.etsy.conjecture.data.*;
+
+import java.util.*;
 
 /**
  *  Current search ads control. Remove after current exp.
  */
-public class ControlOptimizer extends SGDOptimizer {
+public class ControlOptimizer<L extends Label> extends SGDOptimizer<L> {
 
     private StringKeyedVector summedGradients = new StringKeyedVector();
 

--- a/src/main/java/com/etsy/conjecture/model/ElasticNetOptimizer.java
+++ b/src/main/java/com/etsy/conjecture/model/ElasticNetOptimizer.java
@@ -1,13 +1,8 @@
 package com.etsy.conjecture.model;
 
-import com.etsy.conjecture.data.LazyVector;
-import com.etsy.conjecture.data.Label;
-import com.etsy.conjecture.data.LabeledInstance;
-import java.util.Collection;
-import com.etsy.conjecture.Utilities;
-import com.etsy.conjecture.data.StringKeyedVector;
+import com.etsy.conjecture.data.*;
 
-public class ElasticNetOptimizer extends SGDOptimizer implements LazyVector.UpdateFunction {
+public class ElasticNetOptimizer<L extends Label> extends SGDOptimizer<L> implements LazyVector.UpdateFunction {
 
     @Override
     public StringKeyedVector getUpdate(LabeledInstance instance) {

--- a/src/main/java/com/etsy/conjecture/model/MIRAOptimizer.java
+++ b/src/main/java/com/etsy/conjecture/model/MIRAOptimizer.java
@@ -1,18 +1,12 @@
 package com.etsy.conjecture.model;
 
-import com.etsy.conjecture.data.LazyVector;
-import com.etsy.conjecture.data.StringKeyedVector;
-import static com.google.common.base.Preconditions.checkArgument;
-import com.etsy.conjecture.Utilities;
-import com.etsy.conjecture.data.Label;
-import com.etsy.conjecture.data.LabeledInstance;
-import com.etsy.conjecture.data.RealValuedLabel;
+import com.etsy.conjecture.data.*;
 
 /**
  *  MIRA takes care of the full update. This is basically just a passthrough to
  *  the MIRA getGradients.
  */
-public class MIRAOptimizer extends SGDOptimizer {
+public class MIRAOptimizer<L extends Label> extends SGDOptimizer<L> {
 
     @Override
     public StringKeyedVector getUpdate(LabeledInstance instance) {


### PR DESCRIPTION
If you provide this, it'll just output an unsorted multipart sequencefile. Potentially much quicker on large datasets.